### PR TITLE
app.py: simplify regex for messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ posts_url = f"{base_url}/post/"
 # Listens to incoming messages that contain "hello"
 # To learn available listener arguments, visit 
 # https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
-@app.message(re.compile("(@\d\d*)"))
+@app.message(re.compile("(@\d+)"))
 def post_link(say, context):
     for match in context['matches']:
         number = match.replace('@','')


### PR DESCRIPTION
Use `\d+` instead of `\d\d*`, does the same thing (1 or more matches vs 1 match followed by 0 or more matches).

GitHub web interface automatically adds a trailing newline.